### PR TITLE
Try to get recipe pages to remove image on harsh H/W resize

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -285,7 +285,7 @@ a:hover {
 
 /* Instructions Table */
 .instructions-table {
-	widows: 90%;
+	width: 100%;
 }
 
 .instructions-td {

--- a/js/main.js
+++ b/js/main.js
@@ -25,10 +25,18 @@ const toggleIngredientRowComplete = (element, tableName='ingredients-table') => 
 
 // Recipe pages, resize the image to fit ingredients table height
 const resizeRecipeImage = (tableName='ingredients-table') => {
-    newHeight = document.getElementById(tableName).offsetHeight;
+    table = document.getElementById(tableName);
+    newHeight = table.offsetHeight;
+    newWidth = table.offsetWidth;
     recipeImage = document.getElementById('recipe-img');
 
-    recipeImage.style.height = `${newHeight}px`;
+    if (newHeight - newWidth > 75) {
+        recipeImage.style.display = "none";
+    } else {
+        recipeImage.style.display = "inline";
+        recipeImage.style.height = `${newHeight}px`;
+        recipeImage.style.width = `${newWidth - 100}px`;
+    }
 };
 
 // Instructions table check boxes


### PR DESCRIPTION
This PR tries to solve the issue of the recipe image overflowing the container or just being weird looking and distorted if the Height/Width ratio of the ingredients table is too lopsided in terms of height.